### PR TITLE
Update peptideSeq.insert

### DIFF
--- a/src/converters/FragSpectrumScanDatabase.cpp
+++ b/src/converters/FragSpectrumScanDatabase.cpp
@@ -77,7 +77,7 @@ std::string FragSpectrumScanDatabase::decoratePeptide(const ::percolatorInNs::pe
   mods.sort(greater<std::pair<int,std::string> >());
   std::list<std::pair<int,std::string> >::const_iterator it;
   for(it=mods.begin();it!=mods.end();++it) {
-    peptideSeq.insert(it->first,it->second);
+    (it->first <= peptideSeq.length()) ? peptideSeq.insert(it->first,it->second) : peptideSeq.insert(peptideSeq.length(),it->second);
   }
   return peptideSeq;
 }


### PR DESCRIPTION
Adding check if the location of PTM is beyond the length of the peptide, we set the the insert position to length of the peptide.
